### PR TITLE
BUG: Fix dependencies, script path logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,14 @@ RUN mkdir -p /opt/afni-latest && \
         linux_openmp_64/3dWarp \
         linux_openmp_64/3dAllineate \
         linux_openmp_64/3dBrickStat \
+        linux_openmp_64/1dtranspose \
+        linux_openmp_64/3dAFNItoNIFTI \
+        linux_openmp_64/3dWarpDrive \
+        linux_openmp_64/3dZeropad \
+        linux_openmp_64/3dcalc \
+        linux_openmp_64/3dcopy \
+        linux_openmp_64/3drefit \
+        linux_openmp_64/3drename \
         linux_openmp_64/cat_matvec
 # Micromamba
 FROM downloader AS micromamba

--- a/docker/files/freesurfer8.0.0-exclude.txt
+++ b/docker/files/freesurfer8.0.0-exclude.txt
@@ -101,7 +101,6 @@ freesurfer/8.0.0/average/Yeo_JNeurophysiol11_MNI152
 freesurfer/8.0.0/DefectLUT.txt
 freesurfer/8.0.0/diffusion
 freesurfer/8.0.0/docs/xml
-freesurfer/8.0.0/fsfast
 freesurfer/8.0.0/lib/bem/ic0.tri
 freesurfer/8.0.0/lib/bem/ic1.tri
 freesurfer/8.0.0/lib/bem/ic2.tri

--- a/ef_code/scripts/check_bids_dir.sh
+++ b/ef_code/scripts/check_bids_dir.sh
@@ -116,13 +116,13 @@ if [ -f $anat_dir/sub-${sub}_ses-${ses}_T1w.nii.gz ];then
 	echo T1 is found. Using $anat_dir/sub-${sub}_ses-${ses}_T1w.nii.gz
 else
 	echo "T1 was not found, looking under name $anat_dir/sub-${sub}_ses-${ses}_T1w.nii.gz"
-	exit
+	exit 1
 fi
 if [ -f $anat_dir/sub-${sub}_ses-${ses}_T2w.nii.gz ];then
 	echo T2 is found. Using $anat_dir/sub-${sub}_ses-${ses}_T2w.nii.gz
 else
 	echo "T2 was not found, looking under name $anat_dir/sub-${sub}_ses-${ses}_T2w.nii.gz"
-	exit
+	exit 1
 fi
 
 #Check for Freesurfer

--- a/ef_code/scripts/create_headmodel.sh
+++ b/ef_code/scripts/create_headmodel.sh
@@ -32,16 +32,23 @@ AUTHORS:
 	Joel Upston'
 echo '%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%'
 }
-SOURCE="$0"
-tmp_link="$( readlink "$SOURCE" )"
-SOURCE="$( dirname "$SOURCE" )"
-if [[ ! $tmp_link = /* ]];then
-	tmp_link=$SOURCE/$tmp_link
+SOURCE="${BASH_SOURCE[0]:-$0}"
+if [[ "$SOURCE" != */* ]]; then
+    SOURCE="$(command -v -- "$SOURCE" || printf '%s' "$SOURCE")"
 fi
+while [[ -L "$SOURCE" ]]; do
+    script_dir="$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)"
+    tmp_link="$(readlink "$SOURCE")"
+    if [[ "$tmp_link" = /* ]]; then
+        SOURCE="$tmp_link"
+    else
+        SOURCE="$script_dir/$tmp_link"
+    fi
+done
 
 #source j_bash_util
 #LINK TO THE SCRIPT SO FIND DIRECTORY
-script_dir="$( dirname "$tmp_link" )"
+script_dir="$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)"
 
 args=$@
 
@@ -155,5 +162,4 @@ else
     cp m2m_$sub/charm_report.html $qa_deriv/charm_report.html
 
 fi
-
 

--- a/ef_code/scripts/ef_pipeline.sh
+++ b/ef_code/scripts/ef_pipeline.sh
@@ -73,15 +73,22 @@ AUTHORS:
 '
 echo '%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%'
 }
-SOURCE="$0"
-tmp_link="$( readlink "$SOURCE" )"
-SOURCE="$( dirname "$SOURCE" )"
-if [[ ! $tmp_link = /* ]];then
-	tmp_link=$SOURCE/$tmp_link
+SOURCE="${BASH_SOURCE[0]:-$0}"
+if [[ "$SOURCE" != */* ]]; then
+    SOURCE="$(command -v -- "$SOURCE" || printf '%s' "$SOURCE")"
 fi
+while [[ -L "$SOURCE" ]]; do
+    script_dir="$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)"
+    tmp_link="$(readlink "$SOURCE")"
+    if [[ "$tmp_link" = /* ]]; then
+        SOURCE="$tmp_link"
+    else
+        SOURCE="$script_dir/$tmp_link"
+    fi
+done
 #LINK TO THE SCRIPT SO FIND DIRECTORY
-script_dir="$( dirname "$tmp_link" )"
-source $script_dir/bash_util.sh
+script_dir="$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)"
+source "$script_dir/bash_util.sh"
 
 args=$@
 
@@ -164,7 +171,12 @@ for sub_dir in $bids_dir/rawdata/sub-$subj*;do
         pretty_echo "Check the bids dir $bid_dir for sub-$sub ses-$ses and run recon-all if needed" |& tee $qa_deriv/EF_pipeline.log
 
         check_bids_dir --bids_dir $bids_dir --sub $sub --ses $ses --fs_lic $fs_lic --fs_threads $fs_threads |& tee $qa_deriv/Bids_Dir_Checking_and_FreeSurfer.log
+        check_bids_status=${PIPESTATUS[0]}
 	    cat $qa_deriv/Bids_Dir_Checking_and_FreeSurfer.log >> $qa_deriv/EF_pipeline.log
+        if [[ $check_bids_status -ne 0 ]]; then
+            error_echo "Required T1 or T2 image was not found for sub-$sub ses-$ses. Exiting pipeline." |& tee -a $qa_deriv/EF_pipeline.log
+            exit $check_bids_status
+        fi
 
         pretty_echo "FINISHED checking the bids dir $bid_dir for sub-$sub ses-$ses" |& tee -a $qa_deriv/EF_pipeline.log
 

--- a/ef_code/scripts/gather_ef_over_simulation.sh
+++ b/ef_code/scripts/gather_ef_over_simulation.sh
@@ -31,16 +31,23 @@ AUTHORS:
 echo '%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%'
 }
 
-SOURCE="$0"
-tmp_link="$( readlink "$SOURCE" )"
-SOURCE="$( dirname "$SOURCE" )"
-if [[ ! $tmp_link = /* ]];then
-	tmp_link=$SOURCE/$tmp_link
+SOURCE="${BASH_SOURCE[0]:-$0}"
+if [[ "$SOURCE" != */* ]]; then
+    SOURCE="$(command -v -- "$SOURCE" || printf '%s' "$SOURCE")"
 fi
+while [[ -L "$SOURCE" ]]; do
+    script_dir="$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)"
+    tmp_link="$(readlink "$SOURCE")"
+    if [[ "$tmp_link" = /* ]]; then
+        SOURCE="$tmp_link"
+    else
+        SOURCE="$script_dir/$tmp_link"
+    fi
+done
 
 #source j_bash_util
 #LINK TO THE SCRIPT SO FIND DIRECTORY
-script_dir="$( dirname "$tmp_link" )"
+script_dir="$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)"
 
 args=$@
 
@@ -158,7 +165,6 @@ for sim_dir in $sub_ses_simnibs/simnibs_sim_*;do
     #echo ${subj},${ebrain[1]},${e_motor[1]},${e_hippo[1]},${e_thal[1]} >> ../results/efield_vals_$(date +%F).csv
 
 done
-
 
 
 


### PR DESCRIPTION
Fixes a bug where final output failed because of missing AFNI dependencies.

Also, the scripts would not run if invoked with `docker run`, you had to shell into the container first. Now fixed.

Also added back fsfast, which provides the `getpwdcmd`, but FS8 doesn't seem to add it to the PATH. I'm not sure what's going on there.